### PR TITLE
Sets Bad Rep to <careeronly />

### DIFF
--- a/amend_qualities.xml
+++ b/amend_qualities.xml
@@ -164,6 +164,10 @@
       <name>Ex-Con</name>
       <karma>-20</karma>
     </quality>
+    <quality> <!-- Bad Rep -->
+      <name>Bad Rep</name>
+      <careeronly />
+    </quality>
     <!-- Region Banned Positive Qualities -->
     <quality> <!-- Barehanded Adept -->
       <name>Barehanded Adept</name>


### PR DESCRIPTION
Disables buying the Bad Rep quality at chargen via the <careeronly /> tag. Can still purchase in career.