### PR TITLE
Setting Dabbler to SR5 0

### DIFF
--- a/Port House Rules/custom_qualities.xml
+++ b/Port House Rules/custom_qualities.xml
@@ -758,8 +758,8 @@
 			  <val>50</val>
 			</skillcategorypointcostmultiplier>
 		  </bonus>
-		  <source>RF</source>
-		  <page>150</page>
+		  <source>SR5</source>
+		  <page>0</page>
 		</quality>
 		<quality> <!-- Infected: Banshee -->
 		  <id>dbe9f55d-0350-4bd6-8e90-1174070558b4</id>


### PR DESCRIPTION
This is to avoid confusion when people are trying to find it. Really should do a book update to set all the house rules stuff to point to the house rule doc instead of SR5 or random books.

Resolves #36 