### PR TITLE
Removing Plague Cloud

### DIFF
--- a/Port House Rules/amend_powers.xml
+++ b/Port House Rules/amend_powers.xml
@@ -29,5 +29,9 @@
         </specificattribute>
       </bonus>
     </power>
+    <power>
+	  <name>Plague Cloud</name>
+      <hide />
+	</power>
   </powers>
 </chummer>


### PR DESCRIPTION
Plague Cloud is banned as Toxic Magic. Removing Plague Cloud.