### PR TITLE
Vulcan Systems "Hotdrop" Rapid-Egress Jetpack System

### DIFF
--- a/Port House Rules/custom_gear.xml
+++ b/Port House Rules/custom_gear.xml
@@ -175,7 +175,7 @@
 			<cost>22000</cost>
 		</gear>
 		<gear>
-			<id>294de1d3-271b-40a2-bc65-6a7e90905807</id>
+			<id>248e1fbb-eec2-46bd-b48c-b752af215be3</id>
 			<name>Vulcan Systems "Hotdrop" Rapid-Egress Jetpack System Refuel</name>
 			<category>Future Tech</category>
 			<rating>0</rating>

--- a/Port House Rules/custom_gear.xml
+++ b/Port House Rules/custom_gear.xml
@@ -17,11 +17,10 @@
     You can obtain the full source code for Chummer5a at
     https://github.com/chummer5a/chummer5a
 -->
-<categories>
-    <category>Future Tech</category>
-</categories>
-
 <chummer>
+	<categories>
+		<category>Future Tech</category>
+	</categories>
 	<gears>
 		<gear>
 			<id>06272a4e-0583-4fcf-b0f3-61f5ce9922e7</id>
@@ -160,7 +159,7 @@
 			<cost>35</cost>
 			<costfor>1</costfor>
 			<weaponbonus>
-			<ap>-2</ap>
+				<ap>-2</ap>
 			</weaponbonus>
 			<ammoforweapontype>crossbow</ammoforweapontype>
 		</gear>

--- a/Port House Rules/custom_gear.xml
+++ b/Port House Rules/custom_gear.xml
@@ -17,6 +17,10 @@
     You can obtain the full source code for Chummer5a at
     https://github.com/chummer5a/chummer5a
 -->
+<categories>
+    <category>Future Tech</category>
+</categories>
+
 <chummer>
 	<gears>
 		<gear>
@@ -156,9 +160,29 @@
 			<cost>35</cost>
 			<costfor>1</costfor>
 			<weaponbonus>
-					<ap>-2</ap>
+			<ap>-2</ap>
 			</weaponbonus>
 			<ammoforweapontype>crossbow</ammoforweapontype>
+		</gear>
+		<gear>
+			<id>294de1d3-271b-40a2-bc65-6a7e90905807</id>
+			<name>Vulcan Systems "Hotdrop" Rapid-Egress Jetpack System</name>
+			<category>Future Tech</category>
+			<rating>0</rating>
+			<source>SL</source>
+			<page>55</page>
+			<avail>18R</avail>
+			<cost>22000</cost>
+		</gear>
+		<gear>
+			<id>294de1d3-271b-40a2-bc65-6a7e90905807</id>
+			<name>Vulcan Systems "Hotdrop" Rapid-Egress Jetpack System Refuel</name>
+			<category>Future Tech</category>
+			<rating>0</rating>
+			<source>SL</source>
+			<page>55</page>
+			<avail>6R</avail>
+			<cost>250</cost>
 		</gear>
 	</gears>
 </chummer>


### PR DESCRIPTION
Resolves #56

Adds the Vulcan Systems "Hotdrop" Rapid-Egress Jetpack System per the rules doc. Creates Future Tech gear category. And while I was at it I beautified the formatting of custom_gear.xml